### PR TITLE
Working with CRC

### DIFF
--- a/core/components/ace/elements/plugins/ace.plugin.php
+++ b/core/components/ace/elements/plugins/ace.plugin.php
@@ -111,7 +111,7 @@ switch ($modx->event->name) {
                     $richText = $modx->getOption('richtext_default');
                     $classKey = $modx->getOption('class_key', $_REQUEST, 'modDocument');
             }
-            if ($richText || $classKey !== 'modDocument') {
+            if ($richText || in_array($classKey, array('modStaticResource','modSymLink','modWebLink','modXMLRPCResource'))) {
                 return;
             }
         }


### PR DESCRIPTION
Line 114 in version 1.3.2
if ($richText || $classKey !== 'modDocument') {

Need to remove check of the class_key, or change it to disable only default non-document classes (modStaticResource, modSymLink, modWebLink and modXMLRPCResource).

Otherwise this editor does not work with any CRC, such as Articles, Tickets and miniShop 2 (in future).
