### PR TITLE
Fixes Ace Plugin errors logged when editing Elements / Resources

### DIFF
--- a/core/components/ace/elements/plugins/ace.plugin.php
+++ b/core/components/ace/elements/plugins/ace.plugin.php
@@ -109,3 +109,6 @@ if ($modx->event->name == 'OnDocFormPrerender' && !$modx->getOption('use_editor'
 if ($script) {
     $modx->controller->addHtml('<script>Ext.onReady(function() {' . $script . '});</script>');
 }
+
+return;
+


### PR DESCRIPTION
This PR addresses #35 by adding a `return` statement at the end of the Plugin.
