### PR TITLE
ACE is not loading as resource editor

### DIFF
--- a/core/components/ace/elements/plugins/ace.plugin.php
+++ b/core/components/ace/elements/plugins/ace.plugin.php
@@ -85,7 +85,7 @@ switch ($modx->event->name) {
         if ($modx->getOption('use_editor')){
             $richText = $modx->controller->resourceArray['richtext'];
             $classKey = $modx->controller->resourceArray['class_key'];
-            if ($richText || in_array($classKey, array('modStaticResource','modSymLink','modWebLink','modXMLRPCResource'))) {
+            if (!$richText || in_array($classKey, array('modStaticResource','modSymLink','modWebLink','modXMLRPCResource'))) {
                 $field = false;
             }
         }


### PR DESCRIPTION
Fix for using ACE as resource editor when setting "which_editor" is set to "ACE" and resource field "richtext" is enabled.
